### PR TITLE
eslint plugin: add support for locally installed eslint configs and plugins

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -68,7 +68,9 @@ jobs:
           sudo apt install nodejs
           sudo npm install -g n
           sudo n stable
-          npm install --prefix $HOME/.node_modules eslint
+          sudo npm install -g eslint
+          # eslint plugins and configs should be installed locally
+          # https://eslint.org/docs/user-guide/migrating-to-6.0.0#plugins-and-shareable-configs-are-no-longer-affected-by-eslints-location
           npm install --prefix $HOME/.node_modules eslint-plugin-html
           npm install --prefix $HOME/.node_modules eslint-plugin-prettier
           npm install --prefix $HOME/.node_modules eslint-config-prettier

--- a/src/statick_web/plugins/web_tool_plugins/eslint_tool_plugin.py
+++ b/src/statick_web/plugins/web_tool_plugins/eslint_tool_plugin.py
@@ -40,7 +40,9 @@ class ESLintToolPlugin(ToolPlugin):  # type: ignore
             format_file_path = format_file_path.expanduser()
 
             if not format_file_path.exists():
-                config_file_path = pathlib.Path(self.plugin_context.resources.get_file(tool_config))
+                config_file_path = pathlib.Path(
+                    self.plugin_context.resources.get_file(tool_config)
+                )
                 install_dir_path = pathlib.Path(install_dir)
                 install_dir_path = install_dir_path.expanduser()
                 shutil.copy(str(config_file_path), str(install_dir_path))

--- a/src/statick_web/plugins/web_tool_plugins/eslint_tool_plugin.py
+++ b/src/statick_web/plugins/web_tool_plugins/eslint_tool_plugin.py
@@ -43,7 +43,7 @@ class ESLintToolPlugin(ToolPlugin):  # type: ignore
                 shutil.copy(str(config_file_path), str(install_dir_path))
                 copied_file = True
 
-            format_file_name = str(format_file_path.resolve())
+            format_file_name = str(format_file_path)
         else:
             format_file_name = self.plugin_context.resources.get_file(tool_config)
 

--- a/src/statick_web/plugins/web_tool_plugins/eslint_tool_plugin.py
+++ b/src/statick_web/plugins/web_tool_plugins/eslint_tool_plugin.py
@@ -1,7 +1,9 @@
 """Apply eslint tool and gather results."""
 
 import logging
+import pathlib
 import re
+import shutil
 import subprocess
 from typing import List, Match, Optional, Pattern
 
@@ -29,7 +31,25 @@ class ESLintToolPlugin(ToolPlugin):  # type: ignore
         if user_config is not None:
             tool_config = user_config
 
-        format_file_name = self.plugin_context.resources.get_file(tool_config)
+        install_dir = self.plugin_context.config.get_tool_config(
+            self.get_name(), level, "install_dir"
+        )
+        copied_file = False
+        if install_dir is not None:
+            format_file_path = pathlib.Path(install_dir, tool_config)
+            format_file_path = format_file_path.expanduser()
+
+            if not format_file_path.exists():
+                config_file_path = pathlib.Path(self.plugin_context.resources.get_file(tool_config))
+                install_dir_path = pathlib.Path(install_dir)
+                install_dir_path = install_dir_path.expanduser()
+                shutil.copy(str(config_file_path), str(install_dir_path))
+                copied_file = True
+
+            format_file_name = str(format_file_path.resolve())
+        else:
+            format_file_name = self.plugin_context.resources.get_file(tool_config)
+
         flags = []  # type: List[str]
         if format_file_name is not None:
             flags += ["-c", format_file_name]
@@ -61,11 +81,18 @@ class ESLintToolPlugin(ToolPlugin):  # type: ignore
                         "%s failed! Returncode = %d", tool_bin, ex.returncode
                     )
                     logging.warning("%s exception: %s", self.get_name(), ex.output)
+                    if copied_file:
+                        self.remove_config_file(install_dir, tool_config)
                     return None
 
             except OSError as ex:
                 logging.warning("Couldn't find %s! (%s)", tool_bin, ex)
+                if copied_file:
+                    self.remove_config_file(install_dir, tool_config)
                 return None
+
+        if copied_file:
+            self.remove_config_file(install_dir, tool_config)
 
         for output in total_output:
             logging.debug("%s", output)
@@ -79,10 +106,19 @@ class ESLintToolPlugin(ToolPlugin):  # type: ignore
 
     # pylint: enable=too-many-locals
 
+    def remove_config_file(self, install_dir, tool_config):
+        """Remove config file automatically copied into directory."""
+        format_file_path = pathlib.Path(install_dir, tool_config)
+        format_file_path = format_file_path.expanduser()
+        if format_file_path.exists():
+            format_file_path.unlink()
+
     def parse_output(self, total_output: List[str]) -> List[Issue]:
         """Parse tool output and report issues."""
         eslint_re = r"(.+):(\d+):(\d+):\s(.+)\s\[(.+)\/(.+)\]"
+        eslint_error_re = r"(.+):(\d+):(\d+):\s(.+):\s(.+)\s\[(.+)]"
         parse = re.compile(eslint_re)  # type: Pattern[str]
+        err_parse = re.compile(eslint_error_re)  # type: Pattern[str]
         issues = []  # type: List[Issue]
 
         for output in total_output:
@@ -90,6 +126,7 @@ class ESLintToolPlugin(ToolPlugin):  # type: ignore
             count = 0
             for line in lines:
                 match = parse.match(line)  # type: Optional[Match[str]]
+                err_match = err_parse.match(line)  # type: Optional[Match[str]]
                 if match:
                     severity_str = match.group(5).lower()
                     severity = 3
@@ -108,6 +145,25 @@ class ESLintToolPlugin(ToolPlugin):  # type: ignore
                             match.group(6),
                             severity,
                             match.group(4),
+                            None,
+                        )
+                    )
+                elif err_match:
+                    severity_str = err_match.group(6).lower()
+                    severity = 3
+                    if severity_str == "error":
+                        severity = 5
+
+                    count += 1
+
+                    issues.append(
+                        Issue(
+                            err_match.group(1),
+                            err_match.group(2),
+                            self.get_name(),
+                            err_match.group(4),
+                            severity,
+                            err_match.group(5),
                             None,
                         )
                     )

--- a/src/statick_web/plugins/web_tool_plugins/eslint_tool_plugin.py
+++ b/src/statick_web/plugins/web_tool_plugins/eslint_tool_plugin.py
@@ -5,7 +5,7 @@ import pathlib
 import re
 import shutil
 import subprocess
-from typing import List, Match, Optional, Pattern
+from typing import List, Match, Optional, Pattern, Tuple
 
 from statick_tool.issue import Issue
 from statick_tool.package import Package
@@ -19,7 +19,7 @@ class ESLintToolPlugin(ToolPlugin):  # type: ignore
         """Get name of tool."""
         return "eslint"
 
-    def get_format_file(self, level: str):
+    def get_format_file(self, level: str) -> Tuple[str, bool]:
         """Retrieve format file path."""
         tool_config = ".eslintrc"
         user_config = self.plugin_context.config.get_tool_config(
@@ -100,12 +100,10 @@ class ESLintToolPlugin(ToolPlugin):  # type: ignore
         if copied_file:
             self.remove_config_file(format_file_name)
 
-        for output in total_output:
-            logging.debug("%s", output)
-
         with open(self.get_name() + ".log", "w") as fid:
             for output in total_output:
                 fid.write(output)
+                logging.debug("%s", output)
 
         issues = self.parse_output(total_output)  # type: List[Issue]
         return issues

--- a/tests/web_tool_plugins/eslint_tool_plugin/no_plugins/rsc/.eslintrc
+++ b/tests/web_tool_plugins/eslint_tool_plugin/no_plugins/rsc/.eslintrc
@@ -1,0 +1,13 @@
+parserOptions:
+  ecmaVersion: 9
+  sourceType: script
+  ecmaFeatures:
+    jsx: false
+env:
+  browser: true
+extends:
+  - "eslint:recommended"
+
+rules:
+  no-console: off
+  camelcase: warn

--- a/tests/web_tool_plugins/eslint_tool_plugin/no_plugins/rsc/config.yaml
+++ b/tests/web_tool_plugins/eslint_tool_plugin/no_plugins/rsc/config.yaml
@@ -4,4 +4,3 @@ levels:
       eslint:
         flags: ""
         config: ".eslintrc"
-        install_dir: "~/.node_modules"

--- a/tests/web_tool_plugins/eslint_tool_plugin/no_plugins/test.js
+++ b/tests/web_tool_plugins/eslint_tool_plugin/no_plugins/test.js
@@ -1,0 +1,1 @@
+console.log('Hello World!');


### PR DESCRIPTION
eslint plugin: adding install_dir config option to specify where eslint and its plugins are installed, automatically copying the specified eslint config file into the install dir (and removing after use) if it doesn't exist in that directory, adding parsing of eslint error lines.

Signed-off-by: Alexander Xydes <alexander.xydes@navy.mil>