### PR TITLE
Explicitly specifying file encoding when opening a file with Python. …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 
-- Specifying an encoding when calling open (pylint: W1514).
+- Specifying an encoding when calling open (pylint: [W1514](https://pylint.pycqa.org/en/latest/technical_reference/features.html)).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 
+- Specifying an encoding when calling open (pylint: W1514).
+
 ### Removed
 
 ## v0.0.6 - 2021-05-28

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@
 
 from setuptools import setup
 
-with open("README.md", encoding="utf8") as f:
-    long_description = f.read()  # pylint: disable=invalid-name
+with open("README.md", encoding="utf8") as fid:
+    long_description = fid.read()  # pylint: disable=invalid-name
 
 TEST_DEPS = [
     "mock",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 from setuptools import setup
 
-with open("README.md") as f:
+with open("README.md", encoding="utf8") as f:
     long_description = f.read()  # pylint: disable=invalid-name
 
 TEST_DEPS = [

--- a/src/statick_web/plugins/tool/eslint_tool_plugin.py
+++ b/src/statick_web/plugins/tool/eslint_tool_plugin.py
@@ -100,7 +100,7 @@ class ESLintToolPlugin(ToolPlugin):  # type: ignore
         if copied_file:
             self.remove_config_file(format_file_name)
 
-        with open(self.get_name() + ".log", "w") as fid:
+        with open(self.get_name() + ".log", "w", encoding="utf8") as fid:
             for output in total_output:
                 fid.write(output)
                 logging.debug("%s", output)

--- a/src/statick_web/plugins/tool/htmllint_tool_plugin.py
+++ b/src/statick_web/plugins/tool/htmllint_tool_plugin.py
@@ -64,7 +64,7 @@ class HTMLLintToolPlugin(ToolPlugin):  # type: ignore
         for output in total_output:
             logging.debug("%s", output)
 
-        with open(self.get_name() + ".log", "w") as fid:
+        with open(self.get_name() + ".log", "w", encoding="utf8") as fid:
             for output in total_output:
                 fid.write(output)
 

--- a/src/statick_web/plugins/tool/jshint_tool_plugin.py
+++ b/src/statick_web/plugins/tool/jshint_tool_plugin.py
@@ -69,7 +69,7 @@ class JSHintToolPlugin(ToolPlugin):  # type: ignore
         for output in total_output:
             logging.debug("%s", output)
 
-        with open(self.get_name() + ".log", "w") as fid:
+        with open(self.get_name() + ".log", "w", encoding="utf8") as fid:
             for output in total_output:
                 fid.write(output)
 

--- a/src/statick_web/plugins/tool/stylelint_tool_plugin.py
+++ b/src/statick_web/plugins/tool/stylelint_tool_plugin.py
@@ -70,7 +70,7 @@ class StylelintToolPlugin(ToolPlugin):  # type: ignore
         for output in total_output:
             logging.debug("%s", output)
 
-        with open(self.get_name() + ".log", "w") as fid:
+        with open(self.get_name() + ".log", "w", encoding="utf8") as fid:
             for output in total_output:
                 fid.write(output)
 


### PR DESCRIPTION
…Fixes pylint W1514 warning.

Signed-off-by: Alexander Xydes <alexander.xydes@navy.mil>