### PR TITLE
Ensure filetype key is in package information before reading the variable. This makes all the tool plugins consistent in how they read in package information.

### DIFF
--- a/src/statick_web/plugins/tool/htmllint_tool_plugin.py
+++ b/src/statick_web/plugins/tool/htmllint_tool_plugin.py
@@ -36,9 +36,13 @@ class HTMLLintToolPlugin(ToolPlugin):  # type: ignore
         user_flags = self.get_user_flags(level)
         flags += user_flags
 
+        files: List[str] = []
+        if "html_src" in package:
+            files += package["html_src"]
+
         total_output: List[str] = []
 
-        for src in package["html_src"]:
+        for src in files:
             try:
                 exe = [tool_bin] + flags + [src]
                 output = subprocess.check_output(


### PR DESCRIPTION
Signed-off-by: Alexander Xydes <alexander.l.xydes.civ@us.navy.mil>